### PR TITLE
Certificate backwards compatibility for SSL tests

### DIFF
--- a/dcs-core/src/test/java/com/dcentralized/core/common/http/netty/Netty2WaySslAuthTest.java
+++ b/dcs-core/src/test/java/com/dcentralized/core/common/http/netty/Netty2WaySslAuthTest.java
@@ -71,21 +71,26 @@ import org.junit.rules.TemporaryFolder;
 public class Netty2WaySslAuthTest {
     public static final String JAVAX_NET_SSL_TRUST_STORE = "javax.net.ssl.trustStore";
     public static final String JAVAX_NET_SSL_TRUST_STORE_PASSWORD = "javax.net.ssl.trustStorePassword";
+    public static final String JDK_NET_SSL_ALLOW_NON_CA_ANCHOR = "jdk.security.allowNonCaAnchor";
 
     public int securePort = 0;
     private VerificationHost host;
     private TemporaryFolder temporaryFolder;
     private static String savedTrustStore;
     private static String savedTrustStorePassword;
+    private static String savedNonCaAnchor;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+
         savedTrustStore = System.getProperty(JAVAX_NET_SSL_TRUST_STORE);
         savedTrustStorePassword = System.getProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD);
+        savedNonCaAnchor = System.getProperty(JDK_NET_SSL_ALLOW_NON_CA_ANCHOR);
         System.setProperty(JAVAX_NET_SSL_TRUST_STORE,
                 getCanonicalFileForResource("/ssl/trustedcerts.jks")
                         .getCanonicalPath());
         System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD, "changeit");
+        System.setProperty(JDK_NET_SSL_ALLOW_NON_CA_ANCHOR, "true");
     }
 
     @AfterClass
@@ -99,6 +104,11 @@ public class Netty2WaySslAuthTest {
             System.clearProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD);
         } else {
             System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD, savedTrustStorePassword);
+        }
+        if (savedNonCaAnchor == null) {
+            System.clearProperty(JDK_NET_SSL_ALLOW_NON_CA_ANCHOR);
+        } else {
+            System.setProperty(JDK_NET_SSL_ALLOW_NON_CA_ANCHOR, savedNonCaAnchor);
         }
     }
 


### PR DESCRIPTION
Netty2WaySslAuthTest tests are currently failing. This seems to have been caused by changed introduced in more recent versions of the Java environment: https://www.oracle.com/java/technologies/javase/8u241-relnotes.html#JDK-8230318

The approach chosen is to set jdk.security.allowNonCaAnchor to true to keep compatibility with certificates used by tests.
An alternative to this would be to re-issue the certificates used by the tests.

Before changes:
```
mvn -Dtest=Netty2WaySslAuthTest test
...
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   Netty2WaySslAuthTest.test2WaySsl:277 Peer principal
[ERROR]   Netty2WaySslAuthTest.testCustomHttp2SslContext:226->test2WaySsl:277 Peer principal
[ERROR]   Netty2WaySslAuthTest.testCustomSslContext:187->test2WaySsl:277 Peer principal
[ERROR] Errors: 
[ERROR]   Netty2WaySslAuthTest.test2WaySslWithHttp2:342 » Timeout TestContext has expire...
[INFO] 
[ERROR] Tests run: 4, Failures: 3, Errors: 1, Skipped: 0
[INFO]
```

After changes:
```
mvn -Dtest=Netty2WaySslAuthTest test
...
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for dcs-core-parent 0.0.1-SNAPSHOT:
[INFO] 
[INFO] dcs-core-parent .................................... SUCCESS [  1.463 s]
[INFO] dcs-core ........................................... SUCCESS [ 48.211 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  49.782 s
[INFO] Finished at: 2021-07-07T00:09:28-07:00
[INFO] ------------------------------------------------------------------------
```