### PR TITLE
Increase netty version from 4.1.42 to 4.1.65

### DIFF
--- a/dcs-core/pom.xml
+++ b/dcs-core/pom.xml
@@ -14,8 +14,8 @@
     <gson.version>2.8.5</gson.version>
     <kryo.version>3.0.2</kryo.version>
     <lucene.version>7.2.1</lucene.version>
-    <netty.version>4.1.42.Final</netty.version>
-    <tcnative.version>2.0.28.Final</tcnative.version>
+    <netty.version>4.1.65.Final</netty.version>
+    <tcnative.version>2.0.40.Final</tcnative.version>
     <assertj.version>3.8.0</assertj.version>
   </properties>
 

--- a/dcs-core/src/main/java/com/dcentralized/core/common/http/netty/NettyChannelContext.java
+++ b/dcs-core/src/main/java/com/dcentralized/core/common/http/netty/NettyChannelContext.java
@@ -29,7 +29,7 @@ import com.dcentralized.core.common.http.netty.NettyChannelPool.NettyChannelGrou
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.util.AttributeKey;
 
 public class NettyChannelContext extends SocketContext {
@@ -78,7 +78,7 @@ public class NettyChannelContext extends SocketContext {
         // sizes require us to pass things like max order and page size.
         // maxOrder determines the allocation chunk size as a multiple of page size
         int maxOrder = 4;
-        return new PooledByteBufAllocator(true, 2, 2, 8192, maxOrder, 64, 32, 16, true);
+        return new PooledByteBufAllocator(true, 2, 2, 8192, maxOrder, 32, 16, true);
     }
 
     public static final String ENABLE_ALPN_PROPERTY_NAME =
@@ -86,7 +86,7 @@ public class NettyChannelContext extends SocketContext {
 
     private static boolean initializeALPNEnabled() {
         String property = System.getProperty(ENABLE_ALPN_PROPERTY_NAME);
-        return (property != null) ? Boolean.parseBoolean(property) : OpenSsl.isAlpnSupported();
+        return (property != null) ? Boolean.parseBoolean(property) : SslProvider.isAlpnSupported(SslProvider.OPENSSL);
     }
 
     private static boolean isALPNEnabled = initializeALPNEnabled();

--- a/dcs-core/src/main/java/com/dcentralized/core/common/http/netty/NettyHttpListener.java
+++ b/dcs-core/src/main/java/com/dcentralized/core/common/http/netty/NettyHttpListener.java
@@ -41,7 +41,6 @@ import io.netty.handler.codec.http.cors.CorsConfig;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -230,7 +229,7 @@ public class NettyHttpListener implements ServiceRequestListener {
             throw new IllegalStateException("listener already started");
         }
 
-        SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+        SslProvider provider = SslProvider.isAlpnSupported(SslProvider.OPENSSL) ? SslProvider.OPENSSL : SslProvider.JDK;
         SslContextBuilder builder = SslContextBuilder.forServer(new File(certFile),
                 new File(keyFile), keyPassphrase);
 


### PR DESCRIPTION
Updating to this version of netty fixes 7 known CVEs for netty 4.1.42 uncovered in 2020/2021: https://www.cvedetails.com/product/60533/Netty-Netty.html?vendor_id=20711

There are a couple deprecated methods:
* `isAlpnSupported()` is marked deprecated https://netty.io/4.1/api/io/netty/handler/ssl/OpenSsl.html#isAlpnSupported--
* On `PooledByteBufAllocator`, tinyCache has been deprecated https://javadoc.io/doc/io.netty/netty-all/4.1.61.Final/io/netty/buffer/PooledByteBufAllocator.html
But usage has been changed to not have dcs-core using them.

After changes, all tests aside from SSL tests (fixed on different PR) pass.